### PR TITLE
Add missing break statement in hash method for HMAC hash.

### DIFF
--- a/src/harpocrates/hashing.cpp
+++ b/src/harpocrates/hashing.cpp
@@ -43,6 +43,7 @@ namespace vectors
             break;
         case hash_type::HMAC:
             hmac_hash(data, hash);
+	    break;
         default:
             sha1_hash(data, hash);
             break;            


### PR DESCRIPTION
The switch statement was missing a break statement which causes the HMAC to be overwritten by a SHA-1 hash. By adding the break statement, the HMAC no longer gets overwritten.
