### PR TITLE
Clear vectors when using CRC32 hash

### DIFF
--- a/src/harpocrates/hashing.cpp
+++ b/src/harpocrates/hashing.cpp
@@ -165,6 +165,7 @@ namespace vectors
         static auto const table = generate_crc_lookup_table();
 
         std::uint_fast32_t temp = std::uint_fast32_t{0xFFFFFFFFuL} & ~std::accumulate(data.cbegin(), data.cend(), ~std::uint_fast32_t{0} & std::uint_fast32_t{0xFFFFFFFFuL}, [](std::uint_fast32_t checksum, std::uint_fast32_t value){return table[(checksum ^ value) & 0xFFu] ^ (checksum >> 8);});
+        hash.clear();
         hash.reserve(CRC_DIGEST_LENGTH);
         for (int i = CRC_DIGEST_LENGTH - 1; i >= 0; --i)
 	    hash.push_back(*(static_cast<uint8_t *>(static_cast<void *>(&temp)) + i));


### PR DESCRIPTION
If a vector is reused with a CRC32 hash, then the new hash gets appended to the old hash. This is against the intuition of a user, who expects a new hash where the old value is overwritten. This commit fixes the issue by clearing the hash vector before appending the new hash bytes.